### PR TITLE
Add draft long-read QC metric definitions

### DIFF
--- a/docs/metrics_definitions/lr-autosomal_depth_mean_non_gap_white_listed_regions.md
+++ b/docs/metrics_definitions/lr-autosomal_depth_mean_non_gap_white_listed_regions.md
@@ -1,0 +1,9 @@
+# Autosomal depth (mean), non-gap white listed regions
+- **ID:** autosomal_depth_mean
+- **Description:** The mean sequencing depth across autosomal regions, typically restricted to non-gap and high-confidence whitelisted regions of the reference genome. This metric estimates the effective WGS coverage available for variant calling and other downstream analyses.
+- **Implementation details:** Calculate depth over selected autosomal reference intervals after alignment. Exclude regions such as assembly gaps, centromeres, telomeres, and other problematic regions if a whitelist is used. Sum the aligned bases or per-base depths across the selected intervals and divide by the effective region length. The method should specify mapping quality, base quality, supplementary alignment, and secondary alignment filters. For ONT and PacBio human WGS, autosomal mean depth is commonly used to assess whether the dataset is sufficient for SNV, indel, SV, CNV, methylation, and phasing analyses.
+- **Type:** Float, fold coverage (eg. 32.4)
+- **Functionally equivalent implementations:**
+  - mosdepth
+  - samtools depth
+  - bedtools genomecov

--- a/docs/metrics_definitions/lr-bases_with_n_fold_coverage.md
+++ b/docs/metrics_definitions/lr-bases_with_n_fold_coverage.md
@@ -1,0 +1,9 @@
+# Bases with ≥ N-fold coverage
+- **ID:** bases_ge_n_fold_coverage
+- **Description:** The number or proportion of bases in selected genomic regions covered by at least N sequencing reads. Typical thresholds include 5x, 10x, and 15x. This metric estimates the callable fraction of the genome at different depth thresholds.
+- **Implementation details:** Compute per-base depth across the selected genome intervals and count bases where depth is greater than or equal to each requested threshold. Report the count and, preferably, the fraction relative to the total number of evaluated bases. The implementation should define whether depth is calculated over the whole genome, autosomes only, high-confidence regions, or another whitelist. It should also specify read filters such as mapping quality, supplementary alignments, and secondary alignments.
+- **Type:** Integer or Float (eg. 2850000000 bases ≥ 10x; 0.955 fraction ≥ 10x)
+- **Functionally equivalent implementations:**
+  - mosdepth thresholds
+  - samtools depth
+  - bedtools genomecov

--- a/docs/metrics_definitions/lr-contamination.md
+++ b/docs/metrics_definitions/lr-contamination.md
@@ -1,0 +1,9 @@
+# Contamination
+- **ID:** contamination
+- **Description:** The estimated proportion of sequencing data originating from non-target organisms, unrelated human samples, or other unintended DNA sources. Contamination can reduce variant calling accuracy, alter allele balance, inflate apparent yield, and create misleading QC signals.
+- **Implementation details:** Estimate contamination using taxonomic classification, alignment to alternate references, k-mer based methods, or genotype/allele-balance based methods. The method should specify whether it detects non-human contamination, human cross-sample contamination, or both. For ONT and PacBio workflows, contamination assessment may be performed before alignment using reads or after alignment using variant/genotype patterns. The chosen method should be documented because different tools measure different contamination signals.
+- **Type:** Float, fraction or percentage (eg. 0.006; 0.6%)
+- **Functionally equivalent implementations:**
+  - Kraken2
+  - Centrifuge
+  - VerifyBamID

--- a/docs/metrics_definitions/lr-genome_coverage_uniformity.md
+++ b/docs/metrics_definitions/lr-genome_coverage_uniformity.md
@@ -1,0 +1,8 @@
+# Genome coverage uniformity
+- **ID:** genome_coverage_uniformity
+- **Description:** A measure of how evenly sequencing depth is distributed across the evaluated genome. Uniform coverage supports consistent variant detection, whereas non-uniform coverage may produce under-covered regions, false negatives, or biased copy-number estimates.
+- **Implementation details:** Calculate coverage distribution across selected genomic bins or bases and summarize evenness using a defined statistic such as coverage quartiles. The implementation should define bin size, included genomic intervals, and alignment filters. 
+- **Type:** Structured summary (eg. coverage quartiles)
+- **Functionally equivalent implementations:**
+  - mosdepth
+  - bedtools genomecov

--- a/docs/metrics_definitions/lr-heterozygous_homozygous_ratio_snvs_indels.md
+++ b/docs/metrics_definitions/lr-heterozygous_homozygous_ratio_snvs_indels.md
@@ -1,0 +1,9 @@
+# Heterozygous / Homozygous ratio (SNVs | Indels)
+- **ID:** heterozygous_homozygous_ratio
+- **Description:** The ratio of heterozygous variant calls to homozygous alternate variant calls. It may be reported separately for SNVs and indels. In human germline WGS, this metric is used as a QC indicator for sample consistency, coverage adequacy, contamination, and variant calling behavior.
+- **Implementation details:** Classify genotyped variant calls as heterozygous or homozygous alternate using the GT field in the VCF, then divide the heterozygous count by the homozygous alternate count. The implementation should define whether missing, reference, multi-allelic, sex chromosome, and non-diploid calls are included. For autosomal human WGS, SNV Het/Hom ratios are often expected to be approximately 1.5-2.0, but the expected value depends on ancestry, relatedness, sample type, filtering, and region selection. Low values may indicate allelic dropout or low coverage; high values may indicate contamination or mixed samples.
+- **Type:** Float (eg. 1.72)
+- **Functionally equivalent implementations:**
+  - bcftools stats
+  - RTG Tools vcfstats
+  - hap.py

--- a/docs/metrics_definitions/lr-indel_count.md
+++ b/docs/metrics_definitions/lr-indel_count.md
@@ -1,0 +1,9 @@
+# Indel count
+- **ID:** small_indel_count
+- **Description:** The total number of insertion and deletion variants less than 50 bp in length identified relative to the reference genome. Indels may be reported separately as insertion and deletion events. Long-read sequencing improves detection of indels in repetitive, low-complexity, and structurally challenging genomic regions.
+- **Implementation details:** Count insertion and deletion alleles in the final VCF after selected filters. Count insertion and deletion alleles ≤50 bp in the final VCF after selected filters. The implementation should specify how complex variants are handled, whether multi-allelic records are split, and whether only PASS calls are included.
+- **Type:** Integer or structured counts (eg. 790000 total; 520000 insertions; 270000 deletions)
+- **Functionally equivalent implementations:**
+  - bcftools stats
+  - RTG Tools vcfstats
+  - hap.py

--- a/docs/metrics_definitions/lr-insertions_and_deletions_count.md
+++ b/docs/metrics_definitions/lr-insertions_and_deletions_count.md
@@ -1,0 +1,8 @@
+# Insertions and Deletions count
+- **ID:** small_insertions_deletions_count
+- **Description:** The separate counts of small (less than 50bp) insertion and deletion events in the variant call set. This provides more detailed information than total indel count and helps identify systematic bias in long-read variant calling.
+- **Implementation details:** Split indel variants into insertion and deletion categories based on the length difference between the reference and alternate allele, or based on the symbolic variant type for larger events. Count each category after applying the selected filters. The implementation should specify handling of complex variants, multi-allelic records, symbolic alleles, and overlapping alleles. For ONT and PacBio datasets, reporting insertion and deletion counts separately is useful for monitoring platform, chemistry, basecaller, aligner, and caller-specific bias.
+- **Type:** Structured integer counts (eg. insertions: 520000; deletions: 270000)
+- **Functionally equivalent implementations:**
+  - bcftools stats
+  - RTG Tools vcfstats

--- a/docs/metrics_definitions/lr-insertions_deletions_ratio.md
+++ b/docs/metrics_definitions/lr-insertions_deletions_ratio.md
@@ -1,0 +1,8 @@
+# Insertions / Deletions ratio
+- **ID:** small_insertions_deletions_ratio
+- **Description:** The ratio of small insertion variant calls to small deletion variant calls. This metric summarizes the relative balance between insertion and deletion calls and can indicate systematic bias in sequencing, alignment, or variant calling.
+- **Implementation details:** Count insertion events and deletion events using a defined VCF parsing approach, then divide the insertion count by the deletion count. The implementation should define the included variant size range, whether PASS-only variants are used, and how complex variants are classified. In ONT workflows, this metric can be useful for monitoring indel error patterns, particularly in homopolymer or repeat contexts. PacBio HiFi datasets may show a different indel balance due to different error profiles.
+- **Type:** Float (eg. 1.15)
+- **Functionally equivalent implementations:**
+  - bcftools stats
+  - RTG Tools vcfstats

--- a/docs/metrics_definitions/lr-median_read_length.md
+++ b/docs/metrics_definitions/lr-median_read_length.md
@@ -1,0 +1,10 @@
+# Median read length
+- **ID:** median_read_length
+- **Description:** The median length of reads in the dataset. It represents the typical read length and is less sensitive than the mean to the long-tailed read length distribution commonly observed in ONT sequencing.
+- **Implementation details:** Measure the length of each read in FASTQ/BAM and report the median value across all included reads. The implementation should specify whether adapters, clipped bases, filtered reads, or unmapped reads are included. Median read length is useful for assessing fragmentation, DNA extraction quality, library preparation consistency, and suitability for long-range applications.
+- **Type:** Integer, base pairs (eg. 7800)
+- **Functionally equivalent implementations:**
+  - seqkit stats
+  - NanoPlot
+  - pycoQC
+  - samtools stats

--- a/docs/metrics_definitions/lr-median_read_quality.md
+++ b/docs/metrics_definitions/lr-median_read_quality.md
@@ -1,0 +1,9 @@
+# Median read quality
+- **ID:** median_read_quality
+- **Description:** The median of per-read average quality scores across reads in the dataset. For ONT sequencing, this usually reflects the basecaller-estimated confidence for each read, and serves as a central measure of read-level basecalling quality. This metric is useful for comparing reads within a dataset or across datasets in a given platform, but Q-scores may not be directly comparable between sequencing platforms.
+- **Implementation details:** Calculate the mean quality score for each read from FASTQ quality strings or use the read-level quality value reported by the basecaller. Then take the median across all included reads. The implementation should define whether failed reads, unclassified reads, unmapped reads, or quality-filtered reads are included.
+- **Type:** Float, Phred-scaled quality score (eg. 16.8)
+- **Functionally equivalent implementations:**
+  - Dorado sequencing summary
+  - NanoPlot
+  - pycoQC

--- a/docs/metrics_definitions/lr-phase_block_ng50.md
+++ b/docs/metrics_definitions/lr-phase_block_ng50.md
@@ -1,0 +1,7 @@
+# Phase block NG50
+- **ID:** phase_block_ng50
+- **Description:** The phase block length L such that 50% of the expected genome size, or a defined target genome size, is contained in phase blocks of length greater than or equal to L. It is analogous to NG50 for assemblies, but applied to phased haplotype blocks rather than contigs. For long reads, this metric reflects haplotype continuity and is a key indicator of long-range phasing performance.
+- **Implementation details:** Obtain phase block intervals from the phased VCF or phasing output, calculate the length of each phase block, sort blocks by length in descending order, and accumulate block lengths until 50% of the chosen target genome size is reached. The block length at this point is the Phase Block NG50. The implementation should define the target genome size, whether only autosomes are included, how gaps and unphased regions are handled, and whether phase-set IDs from the PS tag or external block definitions are used. For ONT and PacBio data, Phase Block NG50 is strongly influenced by read length, read depth, heterozygous variant density, mapping quality, and phasing algorithm.
+- **Type:** Integer, base pairs (eg. 28500000)
+- **Functionally equivalent implementations:**
+  - WhatsHap stats

--- a/docs/metrics_definitions/lr-read_n50.md
+++ b/docs/metrics_definitions/lr-read_n50.md
@@ -1,0 +1,10 @@
+# Read N50
+- **ID:** read_n50
+- **Description:** The length-weighted median read length in a long-read sequencing dataset. It is defined as the read length L such that 50% of the total sequenced bases are contained in reads with length greater than or equal to L. For ONT and PacBio datasets, Read length N50 is primarily a library and input-DNA integrity metric rather than a direct measure of sequencing accuracy.
+- **Implementation details:** Compute the length of every read, sort reads in descending order by length, and calculate the cumulative sum of bases. The Read N50 is the read length at which the cumulative sum first reaches at least 50% of the total base yield. For ONT workflows this can be computed from FASTQ/BAM read lengths after basecalling, and should be reported together with total yield and read quality because a high N50 alone does not imply high accuracy. Ultra-long reads can increase N50, so the full read length distribution should also be reviewed.
+- **Type:** Integer, base pairs (eg. 24500)
+- **Functionally equivalent implementations:**
+  - seqkit stats
+  - NanoPlot
+  - samtools stats
+  - mosdepth

--- a/docs/metrics_definitions/lr-read_number.md
+++ b/docs/metrics_definitions/lr-read_number.md
@@ -1,0 +1,10 @@
+# Read number
+- **ID:** read_number
+- **Description:** The total number of sequencing reads generated in a run or included in an analysis dataset. For long-read sequencing, read number alone is not sufficient to describe output because reads can vary widely in length. It should therefore be interpreted together with total base yield, read length distribution, and read quality.
+- **Implementation details:** Count all reads in the input FASTQ/BAM according to the selected inclusion criteria. The metric should specify whether all reads, pass reads, mapped reads are included. For ONT data, read number may be influenced by pore activity, run duration, library loading, fragmentation, and basecalling/read filtering choices.
+- **Type:** Integer (eg. 18452391)
+- **Functionally equivalent implementations:**
+  - seqkit stats
+  - samtools view -c
+  - NanoPlot
+  - pycoQC

--- a/docs/metrics_definitions/lr-reads_mapped.md
+++ b/docs/metrics_definitions/lr-reads_mapped.md
@@ -1,0 +1,9 @@
+# Reads mapped (%)
+- **ID:** bp_mapped_pct
+- **Description:** The percentage of bases contained within read alignments to the selected reference genome. In long-read sequencing, this metric reflects the usability of reads for reference-based analysis and is affected by read quality, reference completeness, contamination, structural divergence from the reference, and alignment settings.
+- **Implementation details:** Count the number bases contained within either the primary read alignment or within any read alignment and divide by the total number of bases in all reads considered. The implementation should specify whether secondary and supplementary alignments are included or excluded. For ONT and PacBio WGS, primary alignments are usually preferred for sample-level QC. Low mapping percentage can indicate contamination, degraded DNA, poor basecalling quality, wrong reference choice, or library issues.
+- **Type:** Float, percentage (eg. 97.3)
+- **Functionally equivalent implementations:**
+  - samtools flagstat
+  - samtools stats
+  - mosdepth

--- a/docs/metrics_definitions/lr-snv_count.md
+++ b/docs/metrics_definitions/lr-snv_count.md
@@ -1,0 +1,9 @@
+# SNV count
+- **ID:** snv_count
+- **Description:** The total number of single nucleotide variants identified relative to the reference genome. In human WGS, SNV count is used as a broad QC indicator for variant calling completeness and sample consistency.
+- **Implementation details:** Count variant records classified as SNVs in the final variant call set after the selected filters are applied. The implementation should specify whether only PASS variants are counted, whether multi-allelic records are split, and whether counts are limited to autosomes, sex chromosomes, high-confidence regions, or the whole genome. For ONT and PacBio long-read data, SNV counts depend on depth, basecalling model, alignment, variant caller, filtering, and the reference genome build.
+- **Type:** Integer (eg. 3650000)
+- **Functionally equivalent implementations:**
+  - bcftools stats
+  - RTG Tools vcfeval/vcfstats
+  - hap.py

--- a/docs/metrics_definitions/lr-transition_transversion_ti_tv_rate.md
+++ b/docs/metrics_definitions/lr-transition_transversion_ti_tv_rate.md
@@ -1,0 +1,9 @@
+# Transition / Transversion (Ti/Tv) rate
+- **ID:** titv_ratio
+- **Description:** The ratio of transition SNVs to transversion SNVs. Transitions are A↔G and C↔T substitutions; transversions are all other single-base substitutions. Ti/Tv is a widely used variant-callset QC metric because true human germline SNVs have a characteristic enrichment for transitions. For long reads, it is recommended to restrict this estimation to a specific whitelist of consistently diploid regions to prevent confounding true allelic variation from paralogous variation (variants between copies of copy number variable loci) which often features lower Ti/Tv due to distinct evolutionary mechanisms.
+- **Implementation details:** Count SNVs classified as transitions and SNVs classified as transversions in the filtered call set, then divide the transition count by the transversion count. The implementation should specify whether only PASS variants are used and whether counts are restricted to autosomes, high-confidence regions, or the whole genome. For ONT human WGS not restricted to whitelisted diploid regions, Ti/Tv values may be lower than the commonly cited short-read WGS expectation of ~2.0–2.1 (see above), and should therefore be interpreted relative to the platform, caller, chemistry, and filtering strategy used.
+- **Type:** Float (eg. 1.8)
+- **Functionally equivalent implementations:**
+  - bcftools stats
+  - RTG Tools vcfstats
+  - hap.py (note that even when a high-confidence set for false positive comparison is passed to hap.py as “-f”, this is not used for Ti/Tv calculation – rather a whitelist must be explicitly specified via “--location” or similar)

--- a/docs/metrics_definitions/lr-yield_read_bp_bq_10_20_30.md
+++ b/docs/metrics_definitions/lr-yield_read_bp_bq_10_20_30.md
@@ -1,0 +1,10 @@
+# Yield (read/bp BQ 10/20/30)
+- **ID:** yield_bp_q10_q20_q30
+- **Description:** The number of reads, or bases derived from reads, whose read-level (arithmetic) mean quality scores meet or exceed specified quality thresholds such as Q10, Q20, and Q30. Under the Phred model, Q10 approximately corresponds to 90% estimated base accuracy, Q20 to 99% accuracy, and Q30 to 99.9% accuracy. In Oxford Nanopore  long read datasets, thresholds are commonly applied based on the arithmetic mean across all base positions as these scores are calibrated specifically to be accurate at this level.
+- **Implementation details:** For each read, obtain the arithmetic mean of the per-base quality values across the read from the FASTQ/BAM quality string. Count the number of reads whose read-level mean Q-scores meet the selected threshold, and/or the number of bases contained within those reads. When comparing ONT and PacBio datasets, this metric should be interpreted cautiously because quality-score calibration and error profiles differ between platforms, chemistries, and basecallers.
+- **Type:** Integer, bases or reads (eg. 92000000000 bases at Q10)
+- **Functionally equivalent implementations:**
+  - Dorado summary
+  - NanoPlot
+  - seqkit stats
+  - samtools stats

--- a/docs/metrics_definitions/lr-yield_reads_n_bp_or_reads_p25_p50_p75.md
+++ b/docs/metrics_definitions/lr-yield_reads_n_bp_or_reads_p25_p50_p75.md
@@ -1,0 +1,9 @@
+# Yield (reads ≥ N bp or reads ≥ P25, P50, P75)
+- **ID:** yield_reads_ge_n_bp_ge_n_quartile
+- **Description:** The number, fraction, or total bases of reads with length greater than or equal to user-defined read length thresholds such as 10 kb, 25 kb, or 50 kb or summarized using read-length distribution percentiles/quartiles. This metric is useful for assessing the amount of long-range sequence information available in ONT and PacBio datasets for downstream applications such as structural variant detection, repeat resolution, assembly, and phasing.
+- **Implementation details:** Choose one or more read length thresholds and count reads whose observed read length is greater than or equal to each threshold. Report either the read count, the corresponding number of bases, or the fraction of the total dataset represented by those reads. Thresholds should be explicitly specified in the report because different projects may define different cutoffs for long-read applications.
+- **Type:** Integer or Float (eg. 125000 reads ≥ 10000 bp; 0.42 fraction of reads)
+- **Functionally equivalent implementations:**
+  - seqkit stats
+  - NanoPlot
+  - pycoQC


### PR DESCRIPTION
## Summary

This pull request introduces draft long-read QC metric definitions.

The proposed metrics cover:

- Read-level metrics
- Coverage-level metrics
- Variant-level metrics
- Phasing metrics

Definitions follow the existing GA4GH QC markdown structure and are intended as an initial proposal for community review and discussion.

To avoid modifying existing metric definitions, the proposed long-read metrics are introduced as separate files using the `lr-` prefix naming convention. Future harmonization with existing metric definitions can be discussed as part of the review process.

## Included metrics

- Read N50
- Yield (read/bp BQ10/20/30)
- Yield (reads ≥ N bp or reads ≥ P25, P50, P75)
- Read number
- Reads mapped (%)
- Median read quality
- Median read length
- Autosomal depth (mean)
- Bases with ≥ N-fold coverage
- Genome coverage uniformity
- Contamination
- SNV count
- Indel count
- Insertions and deletions count
- Insertions/deletions ratio
- Heterozygous/homozygous ratio
- Transition/transversion (Ti/Tv) rate
- Phase block NG50

## Notes

- These definitions are intended as draft long-read metrics for discussion and review.
- Existing GA4GH metric definitions were not modified.
- Long-read metric definitions were added as separate files using the `lr-` prefix.